### PR TITLE
Fix int overflow when setting interval to value over 32s.

### DIFF
--- a/atmega328/sonoffsc/sonoffsc.ino
+++ b/atmega328/sonoffsc/sonoffsc.ino
@@ -459,7 +459,7 @@ bool linkSet(char * key, int value) {
     if (strcmp_P(key, at_every) == 0) {
         if (5 <= value && value <= 300) {
 
-            every = 1000 * value;
+            every = 1000L * value;
             return true;
         }
     }


### PR DESCRIPTION
Due to integer overflow setting the interval to values over 32 seconds does not work. Promoting the calculation to long maths fixes it.